### PR TITLE
refactor credential validation in EmployeeForm

### DIFF
--- a/src/components/EmployeeForm.tsx
+++ b/src/components/EmployeeForm.tsx
@@ -1,19 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { supabase, hasValidCredentials } from '../lib/supabase';
 import { User } from '../types';
-import { 
-  User as UserIcon, 
-  Save, 
-  X, 
+import {
+  User as UserIcon,
+  Save,
+  X,
   Calendar,
   CreditCard,
   Mail,
-  Phone,
   MapPin,
   DollarSign
 } from 'lucide-react';
-import { format } from 'date-fns';
 
 interface EmployeeFormProps {
   user?: User;
@@ -27,24 +25,6 @@ export const EmployeeForm: React.FC<EmployeeFormProps> = ({
   onSuccess,
 }) => {
   const { profile } = useAuth();
-
-  if (!hasValidCredentials || !supabase) {
-    return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-        <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-6 text-center">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">Ошибка конфигурации</h2>
-          <p className="text-gray-600 mb-4">Система не настроена для работы с базой данных</p>
-          <button
-            onClick={onClose}
-            className="bg-gray-600 text-white px-4 py-2 rounded-lg hover:bg-gray-700 transition-colors"
-          >
-            Закрыть
-          </button>
-        </div>
-      </div>
-    );
-  }
-
   const [formData, setFormData] = useState({
     full_name: user?.full_name || '',
     email: user?.email || '',
@@ -57,6 +37,8 @@ export const EmployeeForm: React.FC<EmployeeFormProps> = ({
   });
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const showError = !hasValidCredentials || !supabase;
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {};
@@ -157,7 +139,20 @@ export const EmployeeForm: React.FC<EmployeeFormProps> = ({
     }
   };
 
-  return (
+  return showError ? (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-6 text-center">
+        <h2 className="text-xl font-semibold text-gray-900 mb-4">Ошибка конфигурации</h2>
+        <p className="text-gray-600 mb-4">Система не настроена для работы с базой данных</p>
+        <button
+          onClick={onClose}
+          className="bg-gray-600 text-white px-4 py-2 rounded-lg hover:bg-gray-700 transition-colors"
+        >
+          Закрыть
+        </button>
+      </div>
+    </div>
+  ) : (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
       <div className="bg-white rounded-xl shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
         <div className="p-6">
@@ -187,7 +182,7 @@ export const EmployeeForm: React.FC<EmployeeFormProps> = ({
             {/* Основная информация */}
             <div className="bg-gray-50 rounded-lg p-4">
               <h3 className="text-lg font-medium text-gray-900 mb-4">Основная информация</h3>
-              
+
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -277,7 +272,7 @@ export const EmployeeForm: React.FC<EmployeeFormProps> = ({
                 <CreditCard className="w-5 h-5" />
                 <span>Паспортные данные</span>
               </h3>
-              
+
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -287,7 +282,9 @@ export const EmployeeForm: React.FC<EmployeeFormProps> = ({
                     type="text"
                     maxLength={4}
                     value={formData.passport_series}
-                    onChange={(e) => setFormData({ ...formData, passport_series: e.target.value.replace(/\D/g, '') })}
+                    onChange={(e) =>
+                      setFormData({ ...formData, passport_series: e.target.value.replace(/\D/g, '') })
+                    }
                     className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
                       errors.passport_series ? 'border-red-300' : 'border-gray-300'
                     }`}
@@ -306,7 +303,9 @@ export const EmployeeForm: React.FC<EmployeeFormProps> = ({
                     type="text"
                     maxLength={6}
                     value={formData.passport_number}
-                    onChange={(e) => setFormData({ ...formData, passport_number: e.target.value.replace(/\D/g, '') })}
+                    onChange={(e) =>
+                      setFormData({ ...formData, passport_number: e.target.value.replace(/\D/g, '') })
+                    }
                     className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
                       errors.passport_number ? 'border-red-300' : 'border-gray-300'
                     }`}


### PR DESCRIPTION
## Summary
- move Supabase credential check after state declarations
- conditionally render configuration error without early return

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React hooks used conditionally and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a47408c4bc8326b3b3c90b7b1bc9ee