### PR TITLE
fix: import leaflet css before tailwind

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,9 @@
+/* Leaflet CSS */
+@import 'leaflet/dist/leaflet.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Leaflet CSS */
-@import 'leaflet/dist/leaflet.css';
 
 /* Fix for Leaflet marker icons */
 .leaflet-marker-icon {


### PR DESCRIPTION
## Summary
- ensure Leaflet CSS is imported before Tailwind directives so Leaflet styles apply correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68a481d2243883269f9f43d7d98c4f1a