### PR TITLE
refactor: remove any types from components

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -70,19 +70,20 @@ export const Auth: React.FC = () => {
         const { error } = await signIn(data.email, data.password);
         if (error) throw error;
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const error = err as { message?: string };
       let errorMessage = 'Произошла ошибка';
-      
-      if (err.message?.includes('email_address_invalid')) {
+
+      if (error.message?.includes('email_address_invalid')) {
         errorMessage = 'Недопустимый email-адрес. Используйте реальный email (например, Gmail, Yandex, Mail.ru)';
-      } else if (err.message?.includes('email_not_confirmed')) {
+      } else if (error.message?.includes('email_not_confirmed')) {
         errorMessage = 'Email не подтвержден. Проверьте почту и перейдите по ссылке подтверждения';
-      } else if (err.message?.includes('invalid_credentials')) {
+      } else if (error.message?.includes('invalid_credentials')) {
         errorMessage = 'Неверный email или пароль';
-      } else if (err.message?.includes('Database error')) {
+      } else if (error.message?.includes('Database error')) {
         errorMessage = 'Ошибка базы данных. Обратитесь к администратору';
       } else {
-        errorMessage = err.message || 'Произошла ошибка';
+        errorMessage = error.message || 'Произошла ошибка';
       }
       
       setError(errorMessage);

--- a/src/components/EmployeeForm.tsx
+++ b/src/components/EmployeeForm.tsx
@@ -80,7 +80,16 @@ export const EmployeeForm: React.FC<EmployeeFormProps> = ({
 
     setLoading(true);
     try {
-      const updateData: any = {
+      interface UpdateData extends Partial<User> {
+        hourly_rate: number | null;
+        passport_series: string | null;
+        passport_number: string | null;
+        passport_issue_date: string | null;
+        passport_issued_by: string | null;
+        updated_at: string;
+      }
+
+      const updateData: UpdateData = {
         full_name: formData.full_name.trim(),
         email: formData.email.trim(),
         role: formData.role,

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { signOut } from '../lib/supabase';
-import { 
-  Zap, 
-  LogOut, 
-  Clock, 
-  CheckSquare, 
-  Package, 
-  BarChart3, 
+import {
+  Zap,
+  LogOut,
+  Clock,
+  CheckSquare,
+  Package,
+  BarChart3,
   Users,
   Settings
 } from 'lucide-react';
 
+type View = 'time' | 'tasks' | 'materials' | 'team' | 'analytics' | 'admin';
+
 interface LayoutProps {
   children: React.ReactNode;
-  onNavigate?: (view: string) => void;
-  currentView?: string;
+  onNavigate?: (view: View) => void;
+  currentView?: View;
 }
 
 export const Layout: React.FC<LayoutProps> = ({ children, onNavigate, currentView }) => {
@@ -87,7 +89,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, onNavigate, currentVie
             {getNavItems().map((item) => (
               <button
                 key={item.view}
-                onClick={() => onNavigate?.(item.view as any)}
+                onClick={() => onNavigate?.(item.view)}
                 className={`flex items-center space-x-2 px-4 py-2 text-sm font-medium rounded-lg transition-colors whitespace-nowrap min-w-max ${
                   currentView === item.view
                     ? 'text-blue-600 bg-blue-50'

--- a/src/components/MapDisplay.tsx
+++ b/src/components/MapDisplay.tsx
@@ -4,7 +4,7 @@ import L from 'leaflet';
 import { MapPin, X } from 'lucide-react';
 
 // Fix for default markers in react-leaflet
-delete (L.Icon.Default.prototype as any)._getIconUrl;
+delete (L.Icon.Default.prototype as L.Icon.Default & { _getIconUrl?: () => string })._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png',
   iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',

--- a/src/components/MaterialManager.tsx
+++ b/src/components/MaterialManager.tsx
@@ -146,14 +146,14 @@ export const MaterialManager: React.FC = () => {
   const getTotalStock = (material: Material) => {
     if (!material.inventory) return 0;
     return material.inventory
-      .filter((inv: any) => inv.location_type === 'warehouse')
+      .filter((inv: MaterialInventory) => inv.location_type === 'warehouse')
       .reduce((sum, inv) => sum + inv.quantity, 0);
   };
 
   const getOnSiteStock = (material: Material) => {
     if (!material.inventory) return 0;
     return material.inventory
-      .filter((inv: any) => inv.location_type === 'on_site')
+      .filter((inv: MaterialInventory) => inv.location_type === 'on_site')
       .reduce((sum, inv) => sum + inv.quantity, 0);
   };
 
@@ -805,7 +805,7 @@ const SuppliersTab: React.FC<SuppliersTabProps> = ({
 // Create/Edit Modal Component
 interface CreateEditModalProps {
   type: 'materials' | 'categories' | 'warehouses' | 'suppliers';
-  item?: any;
+  item?: EditingItem;
   categories: MaterialCategory[];
   warehouses: Warehouse[];
   onClose: () => void;
@@ -820,7 +820,7 @@ const CreateEditModal: React.FC<CreateEditModalProps> = ({
   onClose,
   onSuccess,
 }) => {
-  const [formData, setFormData] = useState<any>({});
+  const [formData, setFormData] = useState<EditingItem>({});
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
 

--- a/src/components/TeamManager.tsx
+++ b/src/components/TeamManager.tsx
@@ -256,7 +256,9 @@ export const TeamManager: React.FC = () => {
             <TrendingUp className="w-4 h-4 text-gray-500" />
             <select
               value={sortBy}
-              onChange={(e) => setSortBy(e.target.value as any)}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                setSortBy(e.target.value as 'name' | 'hours' | 'tasks' | 'earnings')
+              }
               className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
               <option value="name">По имени</option>

--- a/src/components/worker/WorkerSuperScreen.tsx
+++ b/src/components/worker/WorkerSuperScreen.tsx
@@ -22,6 +22,17 @@ interface HistoryEntry {
   earnings: number;
 }
 
+interface TaskUpdate {
+  status: Task['status'];
+  updated_at: string;
+  start_location?: string | null;
+  started_at?: string;
+  total_pause_duration?: number;
+  paused_at?: string | null;
+  completed_at?: string;
+  end_location?: string | null;
+}
+
 export function WorkerSuperScreen() {
   const { profile } = useAuth();
   const { toast } = useToast();
@@ -47,7 +58,12 @@ export function WorkerSuperScreen() {
   const [todayHours, setTodayHours] = useState(0);
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [currentTime, setCurrentTime] = useState(new Date());
-  const [tab, setTab] = useState<'time' | 'tasks'>('tasks');
+  const tabOptions = [
+    { id: 'time', label: 'Время' },
+    { id: 'tasks', label: 'Задачи' },
+  ] as const;
+  type TabId = typeof tabOptions[number]['id'];
+  const [tab, setTab] = useState<TabId>('tasks');
   const [geoVerified, setGeoVerified] = useState(true);
   const [outside, setOutside] = useState(false);
   const [currentSeconds, setCurrentSeconds] = useState(0);
@@ -447,8 +463,8 @@ export function WorkerSuperScreen() {
     }
     setLoading(true);
     try {
-      let location = null;
-      let updateData: any = {
+      let location: string | null = null;
+      let updateData: TaskUpdate = {
         status: newStatus,
         updated_at: new Date().toISOString(),
       };
@@ -524,7 +540,7 @@ export function WorkerSuperScreen() {
         console.warn('Geolocation failed:', locationError);
       }
 
-      let updateData: any = {
+      let updateData: TaskUpdate = {
         status: 'completed',
         completed_at: new Date().toISOString(),
         end_location: location,
@@ -648,18 +664,15 @@ export function WorkerSuperScreen() {
       {/* Табы */}
       <div className="mx-auto max-w-sm px-4 py-3">
         <div className="flex gap-1 bg-slate-100 rounded-lg p-1">
-          {[
-            { id: 'time', label: 'Время' },
-            { id: 'tasks', label: 'Задачи' },
-          ].map((t) => (
+          {tabOptions.map((t) => (
             <button
               key={t.id}
               className={`flex-1 rounded-xl px-3 py-2 text-sm font-medium transition ${
-                tab === (t.id as any)
+                tab === t.id
                   ? 'bg-blue-600 text-white shadow'
                   : 'bg-slate-100 text-slate-700'
               }`}
-              onClick={() => setTab(t.id as any)}
+              onClick={() => setTab(t.id)}
             >
               {t.label}
             </button>


### PR DESCRIPTION
## Summary
- define `AddressSuggestion` and `TaskUpdateData` interfaces in TaskManager
- replace `any` usage with explicit types and generics across components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: React hooks called conditionally; eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a48ef35fa883268cb3b37b8e0acc20